### PR TITLE
Adding a blank page to test start errors

### DIFF
--- a/sample_site/_includes/navigation.njk
+++ b/sample_site/_includes/navigation.njk
@@ -24,6 +24,9 @@
           <li class="unit1">
             <a href="/about.html" class="second-level-link">About</a>
           </li>
+          <li class="unit1">
+            <a href="/blank.html" class="second-level-link">Blank Page</a>
+          </li>
         </ul>
       </div>
     </li>

--- a/sample_site/pages/blank.njk
+++ b/sample_site/pages/blank.njk
@@ -1,0 +1,22 @@
+---
+permalink: /blank.html
+---
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>{{ title | title }}</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+
+    {% include "../_includes/head-js-css.njk" -%}
+  </head>
+  <body>
+    <h1>Blank page</h1>
+    <p>
+      All the template code is properly referenced, but no elements have been
+      added here.
+    </p>
+  </body>
+</html>

--- a/src/js/cagov/navigation.js
+++ b/src/js/cagov/navigation.js
@@ -493,8 +493,7 @@
       document
         .querySelectorAll(".rotate")
         .forEach((/**@type {HTMLElement} */ el) => (el.style.display = "none"));
-      const nav = document.querySelector("#navigation");
-      nav.removeAttribute("aria-hidden");
+      document.querySelector("#navigation")?.removeAttribute("aria-hidden");
     }
   };
 


### PR DESCRIPTION
Working with a student trying to implement the state template, first thing I noticed is we get errors when certain elements are not in place.  Easy to fix, but it would be nice to have a blank page test that has the JS/CSS attached without all the expected navigation components.