### PR TITLE
Accessible, translatable copyright

### DIFF
--- a/sample_site/_includes/global-footer.njk
+++ b/sample_site/_includes/global-footer.njk
@@ -102,10 +102,11 @@
       </ul>
     </div>
   </div>
-  <!-- Copyright Statement -->
+  <!-- Accessible, translatable, Copyright Statement -->
   <div class="copyright">
     <div class="container text-right">
-      Copyright &copy;
+      Copy<span class="d-none">-</span>right
+      <span aria-hidden="true">&copy;</span>
       <span id="thisyear">
         <script>
           document.getElementById('thisyear').appendChild(document.createTextNode(new Date().getFullYear()))


### PR DESCRIPTION
Using the hyphenated word `Copy-right` (not displaying the hyphen) which will translate to other languages (`copyright` will, `Copyright` will not).  Also removing the copyright symbol from screen reading.