### PR TITLE
Fix for Safari checkParent

### DIFF
--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -206,6 +206,19 @@ window.addEventListener("load", () => {
     }
   };
 
+  // Close mobile nav if click outside of nav
+  regularHeader.addEventListener("mouseup", e => {
+    // if the target of the click isn't the navigation container nor a descendant of the navigation
+    if (checkIfMobileView()) {
+      if (
+        navSearchCont !== e.target &&
+        !navSearchCont?.contains(/**@type {Node} */ (e.target))
+      ) {
+        closeMenu();
+      }
+    }
+  });
+
   // on resize function (hide mobile nav)
   window.addEventListener("resize", mobileCheck);
 

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -56,6 +56,7 @@ window.addEventListener("load", () => {
    */
   const checkParent = (parent, child) =>
     !!(
+      parent &&
       child?.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
     );
 

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -55,7 +55,9 @@ window.addEventListener("load", () => {
    * @returns {boolean}
    */
   const checkParent = (parent, child) =>
-    !!(child.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS);
+    !!(
+      child?.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
+    );
 
   // reset navigation function
   const NavReset = () => {

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -115,13 +115,7 @@ window.addEventListener("load", () => {
       const child = /** @type {Node} **/ (e.relatedTarget);
       const parent = /** @type {Node} **/ (e.currentTarget);
 
-      if (
-        e.relatedTarget &&
-        !(
-          child.compareDocumentPosition(parent) &
-          Node.DOCUMENT_POSITION_CONTAINS
-        )
-      ) {
+      if (child && !parent.contains(child)) {
         closeMenu();
       }
     }

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -49,15 +49,16 @@ window.addEventListener("load", () => {
 
   /**
    * True if child is descendant of the parent
-   * @param {HTMLElement} parent
-   * @param {HTMLElement} child
+   * (Must use ParentNode instead of HTMLElement because of Safari)
+   * @param {ParentNode} parent
+   * @param {ParentNode} child
    * @returns {boolean}
    */
   const checkParent = (parent, child) =>
-    child?.parentElement
-      ? child.parentElement === parent
+    child?.parentNode
+      ? child.parentNode === parent
         ? true
-        : checkParent(parent, child.parentElement)
+        : checkParent(parent, child.parentNode)
       : false;
 
   // reset navigation function

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -122,11 +122,6 @@ window.addEventListener("load", () => {
   // Close menu on focusout (tabbing out) event (if target is outside of mobile menu and ignore if focus target is navToggleBtn button)
   navSearchCont.addEventListener("focusout", e => {
     if (checkIfMobileView()) {
-      const p = /** @type {Node} **/ (e.currentTarget);
-      const c = /** @type {Node} **/ (e.relatedTarget);
-
-      console.log(p.compareDocumentPosition(c));
-
       if (
         !checkParent(
           /** @type {Node} **/ (e.currentTarget),

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -54,10 +54,11 @@ window.addEventListener("load", () => {
    * @param {Node} child
    * @returns {boolean}
    */
-  const checkParent = (parent, child) =>
-    !!(
-      child?.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
+  const checkParent = (parent, child) => {
+    return !!(
+      child.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
     );
+  };
   // reset navigation function
   const NavReset = () => {
     //RESET
@@ -124,6 +125,7 @@ window.addEventListener("load", () => {
   navSearchCont.addEventListener("focusout", e => {
     if (checkIfMobileView()) {
       if (
+        e.relatedTarget &&
         !checkParent(
           /** @type {Node} **/ (e.currentTarget),
           /** @type {Node} **/ (e.relatedTarget)

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -56,10 +56,8 @@ window.addEventListener("load", () => {
    */
   const checkParent = (parent, child) =>
     !!(
-      parent &&
       child?.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
     );
-
   // reset navigation function
   const NavReset = () => {
     //RESET

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -49,9 +49,9 @@ window.addEventListener("load", () => {
 
   /**
    * True if child is descendant of the parent
-   * (Must use ParentNode instead of HTMLElement because of Safari)
-   * @param {ParentNode} parent
-   * @param {ParentNode} child
+   * (Must use Node instead of HTMLElement because of Safari)
+   * @param {Node} parent
+   * @param {Node} child
    * @returns {boolean}
    */
   const checkParent = (parent, child) =>
@@ -128,8 +128,8 @@ window.addEventListener("load", () => {
     if (checkIfMobileView()) {
       if (
         !checkParent(
-          /** @type {HTMLElement} **/ (e.currentTarget),
-          /** @type {HTMLElement} **/ (e.relatedTarget)
+          /** @type {Node} **/ (e.currentTarget),
+          /** @type {Node} **/ (e.relatedTarget)
         )
       ) {
         closeMenu();

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -47,18 +47,6 @@ window.addEventListener("load", () => {
 
   const regularHeader = document.querySelector("header");
 
-  /**
-   * True if child is descendant of the parent
-   * (Must use Node instead of HTMLElement because of Safari)
-   * @param {Node} parent
-   * @param {Node} child
-   * @returns {boolean}
-   */
-  const checkParent = (parent, child) => {
-    return !!(
-      child.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS
-    );
-  };
   // reset navigation function
   const NavReset = () => {
     //RESET
@@ -124,11 +112,14 @@ window.addEventListener("load", () => {
   // Close menu on focusout (tabbing out) event (if target is outside of mobile menu and ignore if focus target is navToggleBtn button)
   navSearchCont.addEventListener("focusout", e => {
     if (checkIfMobileView()) {
+      const child = /** @type {Node} **/ (e.relatedTarget);
+      const parent = /** @type {Node} **/ (e.currentTarget);
+
       if (
         e.relatedTarget &&
-        !checkParent(
-          /** @type {Node} **/ (e.currentTarget),
-          /** @type {Node} **/ (e.relatedTarget)
+        !(
+          child.compareDocumentPosition(parent) &
+          Node.DOCUMENT_POSITION_CONTAINS
         )
       ) {
         closeMenu();

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -55,11 +55,7 @@ window.addEventListener("load", () => {
    * @returns {boolean}
    */
   const checkParent = (parent, child) =>
-    child?.parentNode
-      ? child.parentNode === parent
-        ? true
-        : checkParent(parent, child.parentNode)
-      : false;
+    !!(child.compareDocumentPosition(parent) & Node.DOCUMENT_POSITION_CONTAINS);
 
   // reset navigation function
   const NavReset = () => {
@@ -126,6 +122,11 @@ window.addEventListener("load", () => {
   // Close menu on focusout (tabbing out) event (if target is outside of mobile menu and ignore if focus target is navToggleBtn button)
   navSearchCont.addEventListener("focusout", e => {
     if (checkIfMobileView()) {
+      const p = /** @type {Node} **/ (e.currentTarget);
+      const c = /** @type {Node} **/ (e.relatedTarget);
+
+      console.log(p.compareDocumentPosition(c));
+
       if (
         !checkParent(
           /** @type {Node} **/ (e.currentTarget),

--- a/src/scss/cagov/nav-mobile-controls.scss
+++ b/src/scss/cagov/nav-mobile-controls.scss
@@ -35,7 +35,7 @@ header.nav-overlay {
   align-items: center;
   position: relative;
   transform: rotate(0deg);
-  transition: 0.5s ease-in-out;
+  transition: transform 0.5s ease-in-out;
   cursor: pointer;
   color: var(--white, #fff);
   min-width: 2.5rem;


### PR DESCRIPTION
Safari uses Nodes instead of Elements for parents