### PR TITLE
Refactor header and footer to use classless structural CSS

### DIFF
--- a/sample_site/pages/independent-components/cagov-footer/cagov-footer.html
+++ b/sample_site/pages/independent-components/cagov-footer/cagov-footer.html
@@ -9,10 +9,10 @@ title: Components and patterns
   content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
 <!-- Global Footer -->
 <footer class="cagov-footer">
-  <div class="cagov-footer__1-container">
-    <div class="cagov-footer__2-footer-links">
-      <a href="https://www.ca.gov" class="cagov-footer__3-footer-logo">
-        <span class="cagov-sr-only">CA.gov</span>
+  <div>
+    <div>
+      <a href="https://www.ca.gov">
+        <span>CA.gov</span>
         <?xml version="1.0" encoding="utf-8"?><svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 15 378 210"
@@ -51,7 +51,7 @@ title: Components and patterns
             d="M365 174c0-6-5-18-9-22c2-5-1-8-2-10c-1-1-4-2-5-2c-5-7-14-13-28-17c-9-3-19-4-31-4c-1 0-1 0-2 0c-1 0-2 0-4 0c-11 1-27 3-31 3c-2 0-6-2-10-4c-6-2-12-5-17-5c-1 0-1 0-1 0c-5 1-15 7-19 9c-3 1-11 5-14 7c-1 0-2 0-2 0c-6 2-11 9-12 10c0-1-3-4-6-4c0 0-1 0-1 0c-4 2-4 5-4 6c-1 0-2-2-4-2c-1 0-2 0-3 1c-4 2-2 6-3 8c-2 2-7 7-9 11c-1 1 0 5-1 7c-2 4-11 12-12 13c0 1 2 3 5 6c3 2 6 4 8 5c6 0 18-2 21-3c1 0 2 1 4 1c2 0 3 1 6 1c1 0 1 0 2 0c3-1 5-2 6-3c3-3 4-6 7-7c2-1 5-2 7-2c1 0 2 0 3 1C200 187 202 198 200 200c-2 2-3 4-4 5c-4 6-5 12-6 13c-1 0-1 0-2 0c-2 0-5-1-7-1c-1 0-1 0-1 0c-2 1-8 6-6 7c1 0 10 0 20 0h9c0 0 6-5 6-5h14c1 0 1-2 7-5c7-3 4-16 12-26c0 0 3-2 3-2c3 0 8 5 26 5c18 0 23-6 25-6c1 0 4 2 4 3c-8 14 12 29 11 30c-1 0-3-1-6-1c-1 0-3 0-4 1c-3 1-6 5-3 7c1 0 9 0 17 0c5 0 9 0 12 0c1 0 1-2 1-4c0-1 0-2 0-3c1-1 2-5 4-8c2-2 4-4 6-4c1 0 1 0 2 1c4 2 13 3 18 5c2 1 4 2 4 3c0 1-1 1-1 1c0 0-1 0-1 0c-1 0-3-1-5-1c-1 0-2 0-2 0c-2 1-5 3-5 5c0 1 0 2 1 2h22c3 0 2-5 7-16c1-3-7-7-8-13C366 190 365 175 365 174z" />
         </svg>
       </a>
-      <ul class="cagov-footer__4-legal-links">
+      <ul>
         <li>
           <a href="https://www.ca.gov/legal/conditions-of-use/"
             >Conditions of use</a
@@ -67,7 +67,7 @@ title: Components and patterns
           <a href="https://www.ca.gov/about/sitemap/">Sitemap</a>
         </li>
       </ul>
-      <div class="cagov-footer__5-copyright">
+      <div>
         ©
         <span id="thisyear">
           <script>

--- a/sample_site/pages/independent-components/cagov-footer/cagov-footer.html.css
+++ b/sample_site/pages/independent-components/cagov-footer/cagov-footer.html.css
@@ -43,18 +43,6 @@ footer.cagov-footer {
     }
   }
 
-  .cagov-sr-only {
-    position: absolute !important;
-    width: 1px !important;
-    height: 1px !important;
-    padding: 0 !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    clip: rect(0, 0, 0, 0) !important;
-    white-space: nowrap !important;
-    border: 0 !important;
-  }
-
   *,
   *::before,
   *::after {
@@ -63,7 +51,7 @@ footer.cagov-footer {
     padding: 0;
   }
 
-  > div.cagov-footer__1-container {
+  > div {
     width: 100%;
     padding-right: 12px;
     padding-left: 12px;
@@ -83,7 +71,7 @@ footer.cagov-footer {
       max-width: 1176px;
     }
 
-    > div.cagov-footer__2-footer-links {
+    > div {
       display: flex;
       flex-direction: column;
       align-items: start;
@@ -94,10 +82,22 @@ footer.cagov-footer {
         align-items: center;
       }
 
-      > a.cagov-footer__3-footer-logo {
+      > a {
         display: inline-block;
         height: 28px;
         margin-right: 1.5rem;
+
+        > span {
+          position: absolute !important;
+          width: 1px !important;
+          height: 1px !important;
+          padding: 0 !important;
+          margin: -1px !important;
+          overflow: hidden !important;
+          clip: rect(0, 0, 0, 0) !important;
+          white-space: nowrap !important;
+          border: 0 !important;
+        }
 
         > svg {
           height: 100%;
@@ -106,7 +106,7 @@ footer.cagov-footer {
         }
       }
 
-      > ul.cagov-footer__4-legal-links {
+      > ul {
         list-style: none;
         font-size: 1.1rem;
         line-height: 1.5;
@@ -136,7 +136,7 @@ footer.cagov-footer {
         }
       }
 
-      > div.cagov-footer__5-copyright {
+      > div {
         margin-top: 1rem;
         font-size: 1rem;
         line-height: 1.5;

--- a/sample_site/pages/independent-components/cagov-header/cagov-header.html
+++ b/sample_site/pages/independent-components/cagov-header/cagov-header.html
@@ -8,9 +8,9 @@ title: Components and patterns
   name="viewport"
   content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
 <div class="cagov-header">
-  <div class="cagov-header__1-utility">
-    <div class="cagov-header__2-top-bar">
-      <div class="cagov-header__3-official-content">
+  <div>
+    <div>
+      <div>
         <details>
           <summary>Official California website</summary>
           <div>
@@ -21,7 +21,7 @@ title: Components and patterns
         </details>
       </div>
 
-      <div class="cagov-header__3-menu">
+      <div>
         <details>
           <summary>CA.gov menu</summary>
           <div>
@@ -51,11 +51,10 @@ title: Components and patterns
     <!--end cagov-top-bar -->
   </div>
   <!--end cagov-header__1-utility-->
-  <div class="cagov-header__1-bottom-bar">
-    <div class="cagov-header__2-branding">
+  <div>
+    <div>
       <a
         href="https://www.ca.gov/"
-        class="cagov-header__3-logo-link"
         aria-label="Go to the California state government homepage">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -99,13 +98,13 @@ title: Components and patterns
             d="M1550 250l-28-80l-28 80h-84l68 52l-24 80l68-52l68 52l-24-80l68-52h-84Z" />
         </svg>
       </a>
-      <div class="cagov-header__3-search">
+      <div>
         <form
           action="https://www.ca.gov/search/"
           method="get"
           role="search"
           aria-label="Search CA.gov">
-          <label for="cagov-search-input" class="cagov-sr-only"
+          <label for="cagov-search-input"
             >Search CA.gov</label
           >
           <input

--- a/sample_site/pages/independent-components/cagov-header/cagov-header.html.css
+++ b/sample_site/pages/independent-components/cagov-header/cagov-header.html.css
@@ -41,18 +41,6 @@ div.cagov-header {
     }
   }
 
-  .cagov-sr-only {
-    position: absolute !important;
-    width: 1px !important;
-    height: 1px !important;
-    padding: 0 !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    clip: rect(0, 0, 0, 0) !important;
-    white-space: nowrap !important;
-    border: 0 !important;
-  }
-
   *,
   *::before,
   *::after {
@@ -61,10 +49,8 @@ div.cagov-header {
     padding: 0;
   }
 
-  > div.cagov-header__1-bottom-bar,
-  > div.cagov-header__1-utility {
-    > div.cagov-header__2-top-bar,
-    > div.cagov-header__2-branding {
+  > div {
+    > div {
       width: 100%;
       padding-right: 15px;
       padding-left: 15px;
@@ -86,8 +72,13 @@ div.cagov-header {
     }
   }
 
+  > div:first-child {
+    background-color: #f5f9fa;
+    min-height: 42px;
+  }
+
   /* cagov branding styles */
-  > div.cagov-header__1-bottom-bar > div.cagov-header__2-branding {
+  > div:last-child > div {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
@@ -98,7 +89,7 @@ div.cagov-header {
       justify-content: space-between;
     }
 
-    > a.cagov-header__3-logo-link {
+    > a {
       display: inline-block;
       padding: 0.5rem 0;
 
@@ -111,7 +102,7 @@ div.cagov-header {
     }
 
     /* Search styles */
-    > div.cagov-header__3-search > form {
+    > div > form {
       display: flex;
       align-items: center;
       justify-content: center;
@@ -119,6 +110,18 @@ div.cagov-header {
       padding-top: 1rem;
       padding-bottom: 1rem;
       max-width: 350px;
+
+      > label {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        padding: 0 !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        clip: rect(0, 0, 0, 0) !important;
+        white-space: nowrap !important;
+        border: 0 !important;
+      }
 
       > input[type="search"] {
         font-size: 1.1rem;
@@ -150,165 +153,159 @@ div.cagov-header {
     }
   }
 
-  > div.cagov-header__1-utility {
-    background-color: #f5f9fa;
-    min-height: 42px;
+  > div:first-child > div {
+    padding-top: 0.2rem;
+    padding-bottom: 0.5rem;
+    display: flex;
+    flex-direction: column;
 
-    > div.cagov-header__2-top-bar {
-      padding-top: 0.2rem;
-      padding-bottom: 0.5rem;
-      display: flex;
-      flex-direction: column;
+    @media (width >= 360px) {
+      flex-direction: row;
+      align-items: flex-start;
 
-      @media (width >= 360px) {
-        flex-direction: row;
-        align-items: flex-start;
-
-        > div:first-child {
-          width: 62%;
-        }
-
-        > div:last-child {
-          width: 38%;
-        }
-      }
-      @media (width >= 450px) {
-        flex-direction: row;
-        align-items: flex-start;
-
-        > div:first-child {
-          width: 50%;
-        }
-
-        > div:last-child {
-          width: 50%;
-        }
+      > div:first-child {
+        width: 62%;
       }
 
-      > div.cagov-header__3-official-content > details {
-        font-size: 0.875rem;
+      > div:last-child {
+        width: 38%;
+      }
+    }
+    @media (width >= 450px) {
+      flex-direction: row;
+      align-items: flex-start;
+
+      > div:first-child {
+        width: 50%;
+      }
+
+      > div:last-child {
+        width: 50%;
+      }
+    }
+
+    > div {
+      > details {
+        > div {
+          padding-top: 1rem;
+          padding-bottom: 1rem;
+          line-height: 1.5;
+        }
 
         > summary {
-          width: fit-content;
-          padding: 0.35rem 0.5rem;
+          list-style: none;
+          text-decoration: underline;
+          cursor: pointer;
+          display: inline-flex;
+          align-items: center;
+          position: relative;
+          right: 0.5rem;
+
+          &:hover,
+          &:focus {
+            color: #000;
+          }
+
+          &::-webkit-details-marker {
+            display: none;
+          }
+
+          &::after {
+            margin-left: 0.5rem;
+            content: "";
+            display: inline-block;
+            text-decoration: none;
+            position: relative;
+            width: 0.4rem;
+            height: 0.4rem;
+            border-top: 1px solid #000;
+            border-left: 1px solid #000;
+            transform: rotate(225deg);
+            transition: 200ms;
+            vertical-align: middle;
+          }
+        }
+
+        &[open] > summary::after {
+          transform: rotate(45deg);
+          top: 2px;
         }
       }
+    }
 
-      /* cagov menu styles */
-      > div.cagov-header__3-menu {
-        margin-left: 0;
+    > div:first-child > details {
+      font-size: 0.875rem;
+
+      > summary {
+        width: fit-content;
+        padding: 0.35rem 0.5rem;
+      }
+    }
+
+    /* cagov menu styles */
+    > div:last-child {
+      margin-left: 0;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+
+      @media (width >360px) {
+        margin-left: auto;
+        justify-content: flex-end;
+      }
+
+      > details {
+        width: 100%;
         display: flex;
-        align-items: center;
-        justify-content: flex-start;
+        flex-direction: column;
 
-        @media (width >360px) {
-          margin-left: auto;
-          justify-content: flex-end;
+        > summary {
+          text-align: left;
+          padding: 0.35rem 0.5rem;
+
+          @media (width >= 360px) {
+            text-align: right;
+            width: fit-content;
+            align-self: flex-end;
+            right: 0;
+            left: 0.5rem;
+          }
         }
 
-        > details {
-          width: 100%;
+        > div > nav > ul {
+          list-style: none;
           display: flex;
           flex-direction: column;
+          gap: 0.5rem;
+          align-items: flex-start;
+          justify-content: flex-start;
+          padding: 0;
 
-          > summary {
+          @media (width >= 991px) {
+            flex-direction: row;
+          }
+
+          > li {
             text-align: left;
-            padding: 0.35rem 0.5rem;
 
-            @media (width >= 360px) {
-              text-align: right;
-              width: fit-content;
-              align-self: flex-end;
-              right: 0;
-              left: 0.5rem;
+            > a {
+              padding: 0;
+              outline-offset: 0.375rem;
             }
           }
 
-          > div > nav > ul {
-            list-style: none;
-            display: flex;
-            flex-direction: column;
-            gap: 0.5rem;
-            align-items: flex-start;
-            justify-content: flex-start;
-            padding: 0;
-
-            @media (width >= 991px) {
-              flex-direction: row;
-            }
+          @media (width >= 360px) {
+            gap: 1rem;
+            align-items: flex-end;
+            justify-content: flex-end;
 
             > li {
-              text-align: left;
+              text-align: right;
 
               > a {
-                padding: 0;
-                outline-offset: 0.375rem;
+                padding: 0.5rem 0.35rem;
               }
             }
-
-            @media (width >= 360px) {
-              gap: 1rem;
-              align-items: flex-end;
-              justify-content: flex-end;
-
-              > li {
-                text-align: right;
-
-                > a {
-                  padding: 0.5rem 0.35rem;
-                }
-              }
-            }
-          }
-        }
-      }
-
-      > div.cagov-header__3-menu,
-      > div.cagov-header__3-official-content {
-        > details {
-          > div {
-            padding-top: 1rem;
-            padding-bottom: 1rem;
-            line-height: 1.5;
-          }
-
-          > summary {
-            list-style: none;
-            text-decoration: underline;
-            cursor: pointer;
-            display: inline-flex;
-            align-items: center;
-            position: relative;
-            right: 0.5rem;
-
-            &:hover,
-            &:focus {
-              color: #000;
-            }
-
-            &::-webkit-details-marker {
-              display: none;
-            }
-
-            &::after {
-              margin-left: 0.5rem;
-              content: "";
-              display: inline-block;
-              text-decoration: none;
-              position: relative;
-              width: 0.4rem;
-              height: 0.4rem;
-              border-top: 1px solid #000;
-              border-left: 1px solid #000;
-              transform: rotate(225deg);
-              transition: 200ms;
-              vertical-align: middle;
-            }
-          }
-
-          &[open] > summary::after {
-            transform: rotate(45deg);
-            top: 2px;
           }
         }
       }


### PR DESCRIPTION
# Pull Request: Refactor Header and Footer to Classless CSS Architecture

## Description

This PR refactors the `cagov-header` and `cagov-footer` components to adopt a classless internal architecture. All utility and block-specific classes have been stripped from the internal HTML structures, and styling is now entirely driven by structural CSS specificity extending from the main `.cagov-header` and `.cagov-footer` parent containers.

## Changes Made

### HTML Refactoring
- **`cagov-footer.html`**: Removed all internal classes (e.g., `.cagov-footer__1-container`, `.cagov-footer__2-footer-links`, `.cagov-sr-only`). The root `<footer class="cagov-footer">` remains the only class in the component.
- **`cagov-header.html`**: Removed all internal block and element classes (e.g., `.cagov-header__1-utility`, `.cagov-header__2-top-bar`, `.cagov-header__3-official-content`). The root `<div class="cagov-header">` is now the sole class.

### CSS Re-architecture
- **`cagov-footer.html.css`**: Transitioned entirely to descendant and child combinators (`> div > div > a`). Successfully retained accessibility logic by targeting the screen reader `<span/>` specifically within the anchor tag nest.
- **`cagov-header.html.css`**: Migrated all class-based targeting to structural combinators utilizing `:first-child`, `:last-child`, and standard element tags.
- **Resolved Specificity Bugs**: Fixed several cascading `no-descending-specificity` stylelint errors in the header CSS by completely un-nesting and reordering blocks. The flattened structure now strictly obeys ascending specificity (e.g., `0,2,2` comes before `0,2,3`), preventing linter failures without affecting rendering logic.

## Impact
- **Cleaner HTML**: Components are significantly cleaner and easier to read without the verbose BEM-style classes on every node.
- **Strict Scoping**: Styles remain safely encapsulated inside their respective components (`cagov-header`, `cagov-footer`) while relying on standard semantic HTML structures.
- **Linting Compliant**: The refactored CSS passes strict stylelint specifications without descending specificity warnings.

## Review Notes
If future modifications require altering the HTML nesting order (adding or removing intermediate `div` wrappers), the CSS structural paths may need to be updated to match the new DOM topology.
