### PR TITLE
Refactor cagov-utility-header component to classless CSS architecture

### DIFF
--- a/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html
+++ b/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html
@@ -12,11 +12,14 @@ title: Components and patterns
   name="viewport"
   content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
 <div class="cagov-utility-header">
-  <div class="cagov-utility-header__1-utility">
-    <div class="cagov-utility-header__2-container">
-      <div class="cagov-utility-header__3-utility-bar">
-        <!-- CA.gov Logo -->
-        <div class="cagov-utility-header__4-logo">
+  <!-- START > div (Utility Wrapper) -->
+  <div>
+    <!-- START > div > div (Container) -->
+    <div>
+      <!-- START > div > div > div (Utility Bar) -->
+      <div>
+        <!-- START > div:first-of-type (CA.gov Logo) -->
+        <div>
           <a href="https://www.ca.gov"
             ><span class="cagov-sr-only" lang="en">CA.gov website</span>
             <svg
@@ -38,19 +41,19 @@ title: Components and patterns
                 d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-60 1-103-42-103-102C47 92 92 47 150 47c32 0 61 13 87 39l19-47c-29-24-66-38-104-38C110 1 73 15 45 42C16 69 0 107 0 150c0 87 62 149 150 149z" />
               <path
                 fill="#326130"
-                d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-42 0-74-20-91-51H8c19 60 72 98 142 98z" /></svg></a
-          ><!-- end CA.gov Logo -->
+                d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-42 0-74-20-91-51H8c19 60 72 98 142 98z" /></svg></a>
         </div>
+        <!-- END > div:first-of-type (CA.gov Logo) -->
 
-        <!--cagov menu-->
+        <!-- START > details:first-of-type (CA.gov Menu Button) -->
         <details
-          class="cagov-utility-header__4-menu-button"
           name="cagov-utility-header__buttongroup">
           <summary lang="en">CA.gov menu</summary>
         </details>
+        <!-- END > details:first-of-type (CA.gov Menu Button) -->
 
-        <!--cagov collapsible menu content-->
-        <div class="cagov-utility-header__4-utility-menu">
+        <!-- START > div:nth-of-type(2) (CA.gov Menu Content) -->
+        <div>
           <nav aria-label="CA.gov navigation">
             <ul>
               <li>
@@ -70,14 +73,10 @@ title: Components and patterns
             </ul>
           </nav>
         </div>
-        <!--end cagov collapsible menu content-->
+        <!-- END > div:nth-of-type(2) (CA.gov Menu Content) -->
 
-        <!--end cagov menu-->
-
-        <!--Search-->
-
+        <!-- START > details:last-of-type (Search Button) -->
         <details
-          class="cagov-utility-header__4-search-button"
           name="cagov-utility-header__buttongroup">
           <summary>
             <span class="cagov-sr-only" lang="en">CA.gov search</span>
@@ -92,10 +91,10 @@ title: Components and patterns
             </svg>
           </summary>
         </details>
-        <!--End search-->
+        <!-- END > details:last-of-type (Search Button) -->
 
-        <!-- collapsible search content-->
-        <div class="cagov-utility-header__4-search">
+        <!-- START > div:last-of-type (Search Content) -->
+        <div>
           <form
             action="https://www.ca.gov/search/"
             method="get"
@@ -127,15 +126,15 @@ title: Components and patterns
             </button>
           </form>
         </div>
-        <!-- end collapsible search content-->
+        <!-- END > div:last-of-type (Search Content) -->
       </div>
-      <!-- .cagov-utility-bar -->
+      <!-- END > div > div > div (Utility Bar) -->
     </div>
-    <!-- .cagov-container -->
+    <!-- END > div > div (Container) -->
   </div>
-  <!-- .cagov-utility -->
+  <!-- END > div (Utility Wrapper) -->
 </div>
-<!-- .cagov-utility-header -->
+<!-- END div.cagov-utility-header -->
 
 {% set script %} {% include "./cagov-utility-header.html.js" %} {% endset %}
 <script>

--- a/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html.css
+++ b/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html.css
@@ -54,12 +54,14 @@ div.cagov-utility-header {
     border: 0 !important;
   }
 
-  > div.cagov-utility-header__1-utility {
+  /* Utility Wrapper */
+  > div {
     background-color: #f5f9fa;
     min-height: 42px;
     padding: 0.25rem 0;
 
-    > div.cagov-utility-header__2-container {
+    /* Container */
+    > div {
       width: 100%;
       padding-right: 12px;
       padding-left: 12px;
@@ -79,23 +81,17 @@ div.cagov-utility-header {
         max-width: 1176px;
       }
 
-      > div.cagov-utility-header__3-utility-bar {
+      /* Utility Bar */
+      > div {
         width: 100%;
         display: flex;
         flex-wrap: wrap;
         align-items: center;
 
-        > details[name="cagov-utility-header__buttongroup"] {
-          + div {
-            display: none;
-          }
 
-          &[open] + div {
-            display: block;
-          }
-        }
 
-        > div.cagov-utility-header__4-logo {
+        /* CA.gov Logo */
+        > div:first-of-type {
           display: inline-block;
           flex-grow: 1;
           flex-shrink: 0;
@@ -109,7 +105,8 @@ div.cagov-utility-header {
           }
         }
 
-        > details.cagov-utility-header__4-menu-button {
+        /* CA.gov Menu Button */
+        > details:first-of-type {
           > summary {
             margin-left: auto;
             background: none;
@@ -157,7 +154,8 @@ div.cagov-utility-header {
           }
         }
 
-        > details.cagov-utility-header__4-search-button {
+        /* Search Button */
+        > details:last-of-type {
           > summary {
             cursor: pointer;
             display: inline-flex;
@@ -216,8 +214,8 @@ div.cagov-utility-header {
         }
 
         /* Collapsible content styles */
-        > div.cagov-utility-header__4-utility-menu,
-        > div.cagov-utility-header__4-search {
+        > div:nth-of-type(2),
+        > div:last-of-type {
           background-color: #f5f9fa;
           padding-top: 1rem;
           padding-bottom: 1rem;
@@ -226,8 +224,20 @@ div.cagov-utility-header {
           order: 1;
         }
 
-        /* Navigation styles */
-        > div.cagov-utility-header__4-utility-menu > nav > ul {
+        /* Collapsible content toggles */
+        > details:first-of-type,
+        > details:last-of-type {
+          + div {
+            display: none;
+          }
+
+          &[open] + div {
+            display: block;
+          }
+        }
+
+        /* Navigation styles (CA.gov Menu Content) */
+        > div:nth-of-type(2) > nav > ul {
           list-style: none;
           display: flex;
           flex-direction: column;
@@ -248,8 +258,8 @@ div.cagov-utility-header {
           }
         }
 
-        /* Search styles */
-        > div.cagov-utility-header__4-search > form {
+        /* Search styles (Search Content) */
+        > div:last-of-type > form {
           display: flex;
           align-items: center;
           justify-content: center;


### PR DESCRIPTION
# PR Documentation: Refactoring `cagov-utility-header` to Classless CSS Architecture

## Overview
This PR transitions the `cagov-utility-header` component to the modern, structure-based "classless" CSS architecture, bringing it into alignment with the recently updated `cagov-header`, `cagov-footer`, and `cagov-header-full` components. All internal utility BEM-style classes have been stripped from the HTML to reduce DOM footprint, and the CSS has been rewritten to rely on direct descendant and child combinator logic.

## Changes Included

### 1. HTML DOM Cleanup
* **Stripped internal classes**: Removed all internal BEM classes from `cagov-utility-header.html` (e.g., `.cagov-utility-header__1-utility`, `.cagov-utility-header__4-logo`, `.cagov-utility-header__4-search`).
* **Maintained encapsulation**: Preserved the root `<div class="cagov-utility-header">` class, which serves as the CSS namespace boundary for the component.
* **Updated structural documentation**: Replaced the outdated class-based HTML region comments with explicit structural CSS indicators (e.g., `<!-- START > div:nth-of-type(2) (CA.gov Menu Content) -->`) to perfectly map the markup to the new structural stylesheet logic.

### 2. CSS Architectural Overhaul
* **Transitioned to structural selectors**: Rewrote `cagov-utility-header.html.css` to target elements entirely via their DOM placement (e.g., `> div:first-of-type`, `> details:last-of-type`).
* **Visual parity maintained**: All visual alignment, layout grids, and interactive states remain functionally identical to the original component layout.

### 3. Stylelint Compliance
* **Resolved specificity conflicts**: Prevented all `no-descending-specificity` Stylelint warnings through careful, strategic block ordering.
* **Toggles optimization**: Specifically separated the extremely high-specificity `+ div` and `[open] + div` interactive toggles (for menus and search) out of the base declarations and moved them to the very bottom of the CSS block. This allows the compiler to evaluate the lower-specificity base `div` definitions first, fully resolving the descent without requiring `stylelint-disable` overrides.

## Testing & Verification
- `npm run start` local server was used to verify zero visual regressions.
- `npx stylelint` was executed against `cagov-utility-header.html.css` and passed successfully with 0 errors.

> [!NOTE]
> Future updates to this component must rely on DOM structure rather than assigning new classes. If the HTML tree is wrapped or modified, the corresponding CSS structural selectors must be updated accordingly.
