### PR TITLE
Add component README documentation

### DIFF
--- a/sample_site/pages/independent-components/cagov-footer/README.md
+++ b/sample_site/pages/independent-components/cagov-footer/README.md
@@ -1,0 +1,88 @@
+# CA.gov Footer
+
+This component is the standard CA.gov footer shell used to present official statewide branding, legal links, and footer-level attribution. It is included here for reference, implementation consistency, and structural understanding.
+
+This component is not intended for modification. It should remain as-is because it represents official CA.gov branding and a primary CA.gov shell component. Do not restyle, restructure, rename regions, or swap core content patterns unless direction comes from the platform or branding owners.
+
+## Purpose
+
+Use this component when the experience needs the standard CA.gov global footer treatment, including:
+
+- CA.gov branding
+- legal and policy links
+- footer attribution for the State of California
+
+## High-Level Structure
+
+The component is wrapped in:
+
+```html
+<footer class="cagov-footer">
+  <!-- Footer content -->
+</footer>
+```
+
+It is composed of three primary content areas:
+
+1. CA.gov brand link
+2. Footer link list
+3. State attribution
+
+## Region Breakdown
+
+### 1. CA.gov Brand Link
+
+The first content area provides the CA.gov wordmark/logo link back to the main CA.gov site.
+
+Contained areas:
+
+- CA.gov text label
+- CA.gov logo graphic
+
+This region establishes statewide branding and should remain visually and structurally intact.
+
+### 2. Footer Link List
+
+The second content area provides key statewide policy and support destinations.
+
+Contained areas:
+
+- Conditions of use
+- Privacy policy
+- Accessibility
+- Sitemap
+
+These links support common global footer expectations and should remain consistent with the CA.gov shell.
+
+### 3. State Attribution
+
+The final content area provides the copyright line for the State of California, including the current year.
+
+Contained areas:
+
+- copyright symbol
+- current year
+- State of California label
+
+## Structural Outline
+
+```html
+footer.cagov-footer
+  div
+    div
+      a        /* CA.gov brand link */
+      ul       /* Footer links */
+      div      /* State attribution */
+```
+
+## Guidance
+
+- Treat this as a protected shell component, not a customization surface.
+- Do not alter the branding, logo treatment, labels, legal link set, or region order.
+- Do not repurpose the component as a local footer variant.
+- If a project needs different footer behavior, create or use another component rather than editing this one.
+
+## Files
+
+- `cagov-footer.html`: Markup and region structure
+- `cagov-footer.html.css`: Presentation and layout

--- a/sample_site/pages/independent-components/cagov-header-full/README.md
+++ b/sample_site/pages/independent-components/cagov-header-full/README.md
@@ -1,0 +1,94 @@
+# CA.gov Header Full
+
+This component is the full CA.gov header shell used to present official statewide branding and core navigation. It is included here for reference, implementation consistency, and structural understanding.
+
+This component is not intended for modification. It should remain as-is because it represents official CA.gov branding and the primary CA.gov shell component. Do not restyle, restructure, rename regions, or swap core content patterns unless direction comes from the platform or branding owners.
+
+## Purpose
+
+Use this component when the experience needs the full CA.gov global header treatment, including:
+
+- official California government identification
+- utility navigation
+- CA.gov branding
+- search
+- primary site navigation
+
+## High-Level Structure
+
+The component is wrapped in:
+
+```html
+<div class="cagov-header-full">
+  <!-- Utility Bar -->
+  <!-- Bottom Bar / Branding -->
+</div>
+```
+
+It is composed of two primary regions:
+
+1. Utility Bar
+2. Bottom Bar / Branding
+
+## Region Breakdown
+
+### 1. Utility Bar
+
+The first top-level region provides lightweight statewide utility actions and trust messaging.
+
+Contained areas:
+
+- Official California website button
+- Official California website explanatory content
+- Login link
+- Utility menu button
+- Utility navigation content
+
+This region helps users confirm that the site is part of California government and gives quick access to utility-level destinations.
+
+### 2. Bottom Bar / Branding
+
+The second top-level region contains the primary branded shell.
+
+Contained areas:
+
+- CA.gov logo/home link
+- Search button
+- Search form
+- Main menu button
+- Main navigation content
+
+This region is the main branded interaction layer and should be preserved intact to maintain consistency with CA.gov.
+
+## Structural Outline
+
+```html
+div.cagov-header-full
+  div  /* Utility Bar */
+    div
+      details  /* Official California website */
+      div      /* Official California website content */
+      div      /* Login */
+      details  /* Utility menu */
+      div      /* Utility navigation */
+  div  /* Bottom Bar / Branding */
+    div
+      div      /* CA.gov logo */
+      details  /* Search button */
+      div      /* Search form */
+      details  /* Main menu */
+      div      /* Main navigation */
+```
+
+## Guidance
+
+- Treat this as a protected shell component, not a customization surface.
+- Do not alter the branding, logo treatment, labels, or region order.
+- Do not repurpose the component as a local header variant.
+- If a project needs a different header behavior, create or use another component rather than editing this one.
+
+## Files
+
+- `cagov-header-full.html`: Markup and region structure
+- `cagov-header-full.html.css`: Presentation and layout
+- `cagov-header-full.html.js`: Interactive behavior

--- a/sample_site/pages/independent-components/cagov-header/README.md
+++ b/sample_site/pages/independent-components/cagov-header/README.md
@@ -1,0 +1,84 @@
+# CA.gov Header
+
+This component is the standard CA.gov header shell used to present official statewide branding, trust messaging, and core search functionality. It is included here for reference, implementation consistency, and structural understanding.
+
+This component is not intended for modification. It should remain as-is because it represents official CA.gov branding and a primary CA.gov shell component. Do not restyle, restructure, rename regions, or swap core content patterns unless direction comes from the platform or branding owners.
+
+## Purpose
+
+Use this component when the experience needs the standard CA.gov global header treatment, including:
+
+- official California government identification
+- CA.gov navigation access
+- CA.gov branding
+- search
+
+## High-Level Structure
+
+The component is wrapped in:
+
+```html
+<div class="cagov-header">
+  <!-- Utility / Trust Region -->
+  <!-- Branding / Search Region -->
+</div>
+```
+
+It is composed of two primary regions:
+
+1. Utility / Trust Region
+2. Branding / Search Region
+
+## Region Breakdown
+
+### 1. Utility / Trust Region
+
+The first top-level region provides statewide trust messaging and access to the CA.gov menu.
+
+Contained areas:
+
+- Official California website disclosure button
+- Official California website explanatory content
+- CA.gov menu button
+- CA.gov navigation content
+
+This region helps users understand they are on an official California government website and provides quick access to core statewide destinations.
+
+### 2. Branding / Search Region
+
+The second top-level region contains the primary branded shell and search experience.
+
+Contained areas:
+
+- CA.gov logo/home link
+- Search form
+
+This region is the main branded interaction layer and should be preserved intact to maintain consistency with CA.gov.
+
+## Structural Outline
+
+```html
+div.cagov-header
+  div  /* Utility / Trust Region */
+    div
+      div
+        details  /* Official California website */
+      div
+        details  /* CA.gov menu */
+  div  /* Branding / Search Region */
+    div
+      a        /* CA.gov logo */
+      div      /* Search form */
+```
+
+## Guidance
+
+- Treat this as a protected shell component, not a customization surface.
+- Do not alter the branding, logo treatment, labels, or region order.
+- Do not repurpose the component as a local header variant.
+- If a project needs different header behavior, create or use another component rather than editing this one.
+
+## Files
+
+- `cagov-header.html`: Markup and region structure
+- `cagov-header.html.css`: Presentation and layout

--- a/sample_site/pages/independent-components/cagov-utility-header/README.md
+++ b/sample_site/pages/independent-components/cagov-utility-header/README.md
@@ -1,0 +1,96 @@
+# CA.gov Utility Header
+
+This component is the compact CA.gov utility header shell used to present official statewide branding, navigation access, and search within a single utility bar. It is included here for reference, implementation consistency, and structural understanding.
+
+This component is not intended for modification. It should remain as-is because it represents official CA.gov branding and a primary CA.gov shell component. Do not restyle, restructure, rename regions, or swap core content patterns unless direction comes from the platform or branding owners.
+
+## Purpose
+
+Use this component when the experience needs a compact CA.gov utility header treatment, including:
+
+- CA.gov branding
+- CA.gov navigation access
+- search
+
+## High-Level Structure
+
+The component is wrapped in:
+
+```html
+<div class="cagov-utility-header">
+  <!-- Utility Wrapper -->
+</div>
+```
+
+It is composed of one primary utility region containing four functional areas:
+
+1. CA.gov brand link
+2. CA.gov menu button
+3. CA.gov menu content
+4. Search control and search form
+
+## Region Breakdown
+
+### 1. CA.gov Brand Link
+
+The first functional area provides the CA.gov logo link back to the main CA.gov site.
+
+Contained areas:
+
+- CA.gov home link
+- CA.gov logo graphic
+- screen reader label
+
+This region establishes statewide branding and should remain visually and structurally intact.
+
+### 2. CA.gov Menu
+
+The next functional area provides access to statewide navigation.
+
+Contained areas:
+
+- CA.gov menu button
+- CA.gov navigation content
+- links for Services, Departments, About California, and Get help
+
+This region provides access to core CA.gov destinations and should remain consistent with the CA.gov shell.
+
+### 3. Search
+
+The final functional area provides the CA.gov search experience.
+
+Contained areas:
+
+- search button
+- search form
+- search input
+- submit button
+
+This region supports global CA.gov search access and should be preserved intact.
+
+## Structural Outline
+
+```html
+div.cagov-utility-header
+  div   /* Utility Wrapper */
+    div /* Container */
+      div /* Utility Bar */
+        div      /* CA.gov logo */
+        details  /* CA.gov menu button */
+        div      /* CA.gov menu content */
+        details  /* Search button */
+        div      /* Search content */
+```
+
+## Guidance
+
+- Treat this as a protected shell component, not a customization surface.
+- Do not alter the branding, logo treatment, labels, navigation set, search pattern, or region order.
+- Do not repurpose the component as a local header variant.
+- If a project needs different header behavior, create or use another component rather than editing this one.
+
+## Files
+
+- `cagov-utility-header.html`: Markup and region structure
+- `cagov-utility-header.html.css`: Presentation and layout
+- `cagov-utility-header.html.js`: Interactive behavior

--- a/sample_site/pages/independent-components/template-grid/README.md
+++ b/sample_site/pages/independent-components/template-grid/README.md
@@ -1,0 +1,15 @@
+# Template Grid
+
+This stylesheet is simply a slightly reduced Bootstrap Grid `v5.3.8` CSS implementation.
+
+It exists to provide the core grid layout utilities used by the template without including the full Bootstrap framework.
+
+## Notes
+
+- based on Bootstrap Grid `v5.3.8`
+- reduced to the grid-related styles needed by this project
+- intended for layout structure such as containers, rows, columns, and offsets
+
+## File
+
+- `template-grid.html.css`: Reduced Bootstrap Grid stylesheet used by the template

--- a/sample_site/pages/independent-components/template-typography/README.md
+++ b/sample_site/pages/independent-components/template-typography/README.md
@@ -1,0 +1,27 @@
+# Template Typography
+
+This is the essential State Template typography stylesheet. It provides the core type system, font setup, sizing, spacing, and text presentation used across the template.
+
+## What It Covers
+
+This stylesheet includes typography styles for:
+
+- base font-family and font-loading setup
+- root typography variables for font sizes, weights, line heights, and colors
+- global text reset and baseline typography behavior
+- body text
+- links and focus states
+- paragraphs
+- lead text
+- small text
+- button text sizing, including `.btn`, `.btn-lg`, and `.btn-sm`
+- headings `h1` through `h6` and matching utility classes like `.h1` through `.h6`
+- ordered lists, unordered lists, and definition lists
+
+## Purpose
+
+Use this stylesheet as the core typography foundation for the State Template. It establishes consistent text hierarchy and readable defaults across components and page content.
+
+## File
+
+- `template-typography.html.css`: Essential State Template typography stylesheet


### PR DESCRIPTION
## What was done

Added README documentation for the following independent components:

- `cagov-header-full`
- `cagov-header`
- `cagov-footer`
- `cagov-utility-header`
- `template-grid`
- `template-typography`

## Summary

- Documented the structure and main regions for the CA.gov shell components
- Added guidance that the CA.gov shell components are not intended to be modified, since they represent official CA.gov branding and core shell patterns
- Added a concise README for `template-grid` noting that it is a slightly reduced Bootstrap Grid `v5.3.8` CSS file
- Added a README for `template-typography` describing it as the essential State Template typography stylesheet and listing the elements it covers

## Notes

These changes are documentation-only. No component markup, styles, or behavior were changed.
