### PR TITLE
Added independent skip to content component

### DIFF
--- a/sample_site/pages/components-patterns.html
+++ b/sample_site/pages/components-patterns.html
@@ -107,32 +107,6 @@ title: Components and patterns
               >
             </li>
             <li><a href="/samples/featured-search.html">Featured search</a></li>
-            <li><a href="/cagov-header.html">ca.gov header</a></li>
-            <li><a href="/cagov-utility.html">ca.gov utility header</a></li>
-            <li><a href="/cagov-header-full.html">ca.gov full header</a></li>
-            <li><a href="/cagov-footer.html">ca.gov footer</a></li>
-            <li>
-              <a href="/template-accordion.html">Template accordion</a>
-            </li>
-            <li><a href="/template-header-full.html">Template header</a></li>
-            <li><a href="/template-banner.html">Template banner</a></li>
-            <li>
-              <a href="/template-button.html">Template button</a>
-            </li>
-            <li>
-              <a href="/template-page-header.html">Template page header</a>
-            </li>
-            <li>
-              <a href="/template-card.html">Template card</a>
-            </li>
-            <li>
-              <a href="/template-site-footer.html">Template site footer</a>
-            </li>
-            <li>
-              <a href="/template-progress-tracker.html"
-                >Template progress tracker</a
-              >
-            </li>
           </ul>
         </div>
       </div>
@@ -190,6 +164,48 @@ title: Components and patterns
             <li><a href="/samples/progress-bar.html">Progress bar</a></li>
             <li>
               <a href="/samples/progress-block-bold.html">Progress tracker</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <hr />
+
+      <div class="row">
+        <div class="col-lg-6">
+          <h3 class="m-t-0">Independent components</h3>
+        </div>
+        <div class="col-lg-6">
+          <ul>
+            <li><a href="/cagov-header.html">ca.gov header</a></li>
+            <li><a href="/cagov-utility.html">ca.gov utility header</a></li>
+            <li><a href="/cagov-header-full.html">ca.gov full header</a></li>
+            <li><a href="/cagov-footer.html">ca.gov footer</a></li>
+            <li>
+              <a href="/template-accordion.html">Template accordion</a>
+            </li>
+            <li><a href="/template-header-full.html">Template header</a></li>
+            <li><a href="/template-banner.html">Template banner</a></li>
+            <li>
+              <a href="/template-button.html">Template button</a>
+            </li>
+            <li>
+              <a href="/template-page-header.html">Template page header</a>
+            </li>
+            <li>
+              <a href="/template-card.html">Template card</a>
+            </li>
+            <li>
+              <a href="/template-site-footer.html">Template site footer</a>
+            </li>
+            <li>
+              <a href="/template-progress-tracker.html"
+                >Template progress tracker</a
+              >
+            </li>
+            <li>
+              <a href="/template-skip-to-content.html"
+                >Template skip to content</a
+              >
             </li>
           </ul>
         </div>

--- a/sample_site/pages/independent-components/template-skip-to-content/README.md
+++ b/sample_site/pages/independent-components/template-skip-to-content/README.md
@@ -1,0 +1,37 @@
+# Template Skip To Content
+
+The Skip to Content component provides an accessible shortcut that lets keyboard and assistive technology users move directly to the primary page content without tabbing through the full header and navigation.
+
+## Placement
+
+This component should be placed as the first element inside the `<header>` tag.
+
+Putting it first ensures the link is the first interactive control available to keyboard users when they enter the page.
+
+## Expected Behavior
+
+- The link should point to the main content container, typically `#main-content`.
+- The destination element should exist on the page.
+- The component should remain visually hidden until it receives keyboard focus.
+
+## Recommended Structure
+
+```html
+<header>
+	<div id="template-skip-to-content">
+		<a href="#main-content">Skip to Main Content</a>
+	</div>
+
+	<!-- Header branding, navigation, search, etc. -->
+</header>
+
+<main id="main-content">
+	<!-- Primary page content -->
+</main>
+```
+
+## Guidance
+
+- Use this component on pages with persistent header, navigation, or utility content.
+- Keep the link label direct and action-oriented.
+- Do not place this component after other header controls or navigation elements.

--- a/sample_site/pages/independent-components/template-skip-to-content/template-skip-to-content.html
+++ b/sample_site/pages/independent-components/template-skip-to-content/template-skip-to-content.html
@@ -1,0 +1,14 @@
+---
+landing: Components
+permalink: template-skip-to-content.html
+title: Components and patterns
+---
+
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<div id="template-skip-to-content">
+  <a href="#main-content">Skip to Main Content</a>
+</div>
+<style>
+  {% include "./template-skip-to-content.html.css" %}
+</style>

--- a/sample_site/pages/independent-components/template-skip-to-content/template-skip-to-content.html.css
+++ b/sample_site/pages/independent-components/template-skip-to-content/template-skip-to-content.html.css
@@ -1,0 +1,37 @@
+div#template-skip-to-content {
+  position: relative;
+  left: 50% !important;
+  transform: translateX(-50%);
+  z-index: 999;
+  font-family:
+    "Public Sans",
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    "Noto Sans",
+    sans-serif;
+  font-size: calc(1rem + 0.1vw);
+
+  & a {
+    width: 1px;
+    height: 1px;
+    text-align: center;
+    position: absolute !important;
+    left: 50% !important;
+    transform: translateX(-50%);
+    clip: unset;
+    background-color: white;
+    border-radius: 0 0 7px 7px;
+    overflow: hidden;
+    color: #214a68;
+
+    &:focus {
+      width: 250px;
+      height: 27px;
+      padding: 0.5rem 0;
+      outline: 2px solid #0b8ee5;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds README documentation for the Skip to Content component in [sample_site/pages/independent-components/template-skip-to-content/README.md](/Users/kostya/Documents/GitHub/California-State-Web-Template-Development/sample_site/pages/independent-components/template-skip-to-content/README.md).

## What Changed

- Documented the purpose of the Skip to Content component as an accessibility feature for keyboard and assistive technology users.
- Added explicit placement guidance that the component should be the first element inside the `header` tag.
- Documented expected behavior, including linking to the main content region.
- Added a recommended HTML structure example showing the skip link and main content target.
- Added implementation guidance for when and how to use the component.

## Why

This makes the component guidance clearer and helps prevent incorrect placement that would reduce the effectiveness of the skip link for keyboard navigation.

## Testing

- Documentation-only change
- No runtime tests were run