### PR TITLE
Fixed accordion arrow #207

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,7 @@
     "target": "es2020",
     "strict": false,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "_site", "**/node_modules/*"]

--- a/sample_site/pages/samples/accordion.html
+++ b/sample_site/pages/samples/accordion.html
@@ -1,4 +1,5 @@
 <cagov-accordion>
+  <!-- Add the same name attribute to grouped details elements to make them behave like a true accordion. -->
   <details>
     <summary>Add a short, descriptive heading for your topic</summary>
     <div class="accordion-body">

--- a/src/css/cagov/accordion.css
+++ b/src/css/cagov/accordion.css
@@ -55,11 +55,20 @@ cagov-accordion > details {
       height: 0;
 
       &::before {
-        font-family: CaGov;
-        content: "5";
+        content: "";
+        display: inline-block;
+        text-decoration: none;
         position: absolute;
-        font-size: 1.6rem;
-        transition: transform 0.2s;
+        width: 0.5rem;
+        height: 0.5rem;
+        border-top: 2px solid var(--gray-900, #3b3a48);
+        border-left: 2px solid var(--gray-900, #3b3a48);
+        left: 0.55rem;
+        top: 1rem;
+        vertical-align: middle;
+        transform-origin: center;
+        transform: translateY(-50%) rotate(135deg);
+        transition: transform 300ms ease-in-out;
       }
     }
 
@@ -112,7 +121,7 @@ cagov-accordion:defined {
 
       .cagov-open-indicator {
         &::before {
-          transform: rotate(90deg) translateY(-0.2rem);
+          transform: translate(0.125rem, -50%) rotate(225deg);
         }
       }
 

--- a/src/js/cagov/accordion.js
+++ b/src/js/cagov/accordion.js
@@ -19,16 +19,21 @@ window.addEventListener("load", () => {
   class CaGovAccordion extends HTMLElement {
     connectedCallback() {
       this.summaryEl = this.querySelector("summary");
+      this.detailsEl = this.querySelector("details");
+      this.bodyEl = this.querySelector(".accordion-body");
+
+      if (!this.summaryEl || !this.detailsEl || !this.bodyEl) {
+        return;
+      }
+
       // trigger the opening and closing height change animation on summary click
 
       this.setHeight();
-      this.summaryEl.addEventListener("click", this.listen.bind(this));
+      this.detailsEl.addEventListener("toggle", this.setHeight.bind(this));
       this.summaryEl.insertAdjacentHTML(
         "beforeend",
         `<div class="cagov-open-indicator" aria-hidden="true" />`
       );
-      this.detailsEl = this.querySelector("details");
-      this.bodyEl = this.querySelector(".accordion-body");
 
       window.addEventListener(
         "resize",
@@ -42,32 +47,15 @@ window.addEventListener("load", () => {
         this.closedHeightInt = this.summaryEl.scrollHeight + 2;
         this.closedHeight = `${this.closedHeightInt}px`;
 
-        // apply initial height
+        // Apply the height that matches the current open state.
         if (this.detailsEl.hasAttribute("open")) {
-          // if open get scrollHeight
           this.detailsEl.style.height = `${
             this.bodyEl.scrollHeight + this.closedHeightInt
           }px`;
         } else {
-          // else apply closed height
           this.detailsEl.style.height = this.closedHeight;
         }
       });
-    }
-
-    listen() {
-      if (this.detailsEl.hasAttribute("open")) {
-        // was open, now closing
-        this.detailsEl.style.height = this.closedHeight;
-      } else {
-        // was closed, opening
-        window.requestAnimationFrame(() => {
-          // delay so the desired height is readable in all browsers
-          this.detailsEl.style.height = `${
-            this.bodyEl.scrollHeight + this.closedHeightInt
-          }px`;
-        });
-      }
     }
 
     /**

--- a/src/js/cagov/accordion.js
+++ b/src/js/cagov/accordion.js
@@ -29,7 +29,7 @@ window.addEventListener("load", () => {
       // trigger the opening and closing height change animation on summary click
 
       this.setHeight();
-      this.detailsEl.addEventListener("toggle", this.setHeight.bind(this));
+      this.detailsEl.addEventListener("toggle", this.handleToggle.bind(this));
       this.summaryEl.insertAdjacentHTML(
         "beforeend",
         `<div class="cagov-open-indicator" aria-hidden="true" />`
@@ -39,6 +39,34 @@ window.addEventListener("load", () => {
         "resize",
         this.debounce(this.setHeight).bind(this)
       );
+    }
+
+    handleToggle() {
+      if (this.detailsEl.open) {
+        this.closeGroupedDetails();
+      }
+
+      this.setHeight();
+    }
+
+    closeGroupedDetails() {
+      const groupName = this.detailsEl.getAttribute("name");
+
+      if (!groupName) {
+        return;
+      }
+
+      document.querySelectorAll("details[name]").forEach(otherDetailsEl => {
+        const otherDetails = /** @type {HTMLDetailsElement} */ (otherDetailsEl);
+
+        if (
+          otherDetails !== this.detailsEl &&
+          otherDetails.open &&
+          otherDetails.getAttribute("name") === groupName
+        ) {
+          otherDetails.open = false;
+        }
+      });
     }
 
     setHeight() {


### PR DESCRIPTION
## Summary

- Replaced the accordion arrow icon from the CAGov icon font with a CSS border arrow.
- Updated src/js/cagov/accordion.js (line 1) to listen for the native toggle event on the internal details element instead of only reacting to summary clicks.
- This ensures height is recalculated whenever a details element opens or closes, including when the browser automatically closes a sibling in a details[name] group.
- Closed accordion items now return to their original collapsed height instead of retaining the previously open height.
Added a small guard so the component exits cleanly if expected accordion markup is missing.

## Why

- This removes an unnecessary icon font dependency for a simple visual indicator, makes the component less JS/font dependent, and keeps the arrow as a presentation concern handled in CSS.
- Previously, grouped details[name] items could auto-close correctly at the browser level, but the component did not reset the closed item’s inline height, leaving it visually expanded. This change aligns the animated height behavior with native accordion grouping.

