### PR TITLE
Adding aria-expanded and other aria controls to the side navigation toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -271,6 +271,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -294,6 +295,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -665,6 +667,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1797,6 +1800,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2575,9 +2579,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4467,6 +4471,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4597,6 +4602,7 @@
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
       "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -5075,6 +5081,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5703,6 +5710,7 @@
       "integrity": "sha512-78O4c6IswZ9TzpcIiQJIN49K3qNoXTM8zEJzhaTE/xRTCZswaovSEVIa/uwbOltZrk16X4jAxjaOhzz/hTm1Kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^2.3.1",
         "@csstools/css-tokenizer": "^2.2.0",
@@ -5917,6 +5925,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6110,6 +6119,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/sample_site/_includes/layouts/sample.njk
+++ b/sample_site/_includes/layouts/sample.njk
@@ -15,12 +15,13 @@
       <div class="row">
         <div class="col-lg-3 pe-lg-5" role="complementary">
           <!-- Side navigation -->
-          <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+          <details class="side-navigation-toggle" aria-label="Toggle side navigation" aria-expanded="false"
+  aria-controls="side-navigation-content">
             <summary>
               <span class="container d-block">Side navigation</span>
             </summary>
           </details>
-          <div class="container">
+          <div class="container" id="side-navigation-content">
             <nav aria-label="Side navigation" class="side-navigation sticky-6">
               <ul class="list-navigation">
                 {%- for entry in collections.all | allSamples %}

--- a/sample_site/pages/about.html
+++ b/sample_site/pages/about.html
@@ -37,12 +37,14 @@ landing: Components
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/careers.html
+++ b/sample_site/pages/careers.html
@@ -36,12 +36,14 @@ landing: Careers
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/components-patterns.html
+++ b/sample_site/pages/components-patterns.html
@@ -25,12 +25,14 @@ title: Components and patterns
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/content-directory.html
+++ b/sample_site/pages/content-directory.html
@@ -28,12 +28,14 @@ title: Content directory
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-article-title1.html
+++ b/sample_site/pages/news-article-title1.html
@@ -30,12 +30,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-article-title2.html
+++ b/sample_site/pages/news-article-title2.html
@@ -30,12 +30,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-article-title3.html
+++ b/sample_site/pages/news-article-title3.html
@@ -30,12 +30,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-articles.html
+++ b/sample_site/pages/news-articles.html
@@ -25,12 +25,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-blog-title1.html
+++ b/sample_site/pages/news-blog-title1.html
@@ -28,12 +28,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-blog-title2.html
+++ b/sample_site/pages/news-blog-title2.html
@@ -28,12 +28,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-blog.html
+++ b/sample_site/pages/news-blog.html
@@ -25,12 +25,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-press-information.html
+++ b/sample_site/pages/news-press-information.html
@@ -25,12 +25,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-press-release-title1.html
+++ b/sample_site/pages/news-press-release-title1.html
@@ -32,12 +32,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-press-release-title2.html
+++ b/sample_site/pages/news-press-release-title2.html
@@ -32,12 +32,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-press-releases.html
+++ b/sample_site/pages/news-press-releases.html
@@ -25,12 +25,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/news-subscribtion-services.html
+++ b/sample_site/pages/news-subscribtion-services.html
@@ -25,12 +25,14 @@ landing: Components
       <!-- Side navigation -->
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="list navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/newsroom.html
+++ b/sample_site/pages/newsroom.html
@@ -26,12 +26,14 @@ landing: Components
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/our-organization.html
+++ b/sample_site/pages/our-organization.html
@@ -26,12 +26,14 @@ landing: Components
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/samples/side-navigation-level1.html
+++ b/sample_site/pages/samples/side-navigation-level1.html
@@ -1,9 +1,13 @@
-<details class="side-navigation-toggle" aria-label="Toggle side navigation">
+<details
+  class="side-navigation-toggle"
+  aria-label="Toggle side navigation"
+  aria-expanded="false"
+  aria-controls="side-nav-content">
   <summary>
     <span class="container d-block">Side navigation</span>
   </summary>
 </details>
-<div class="container">
+<div class="container" id="side-nav-content">
   <nav aria-label="list navigation" class="side-navigation">
     <ul>
       <li><a href="javascript:;" class="landing active">Landing page</a></li>

--- a/sample_site/pages/samples/side-navigation-level2.html
+++ b/sample_site/pages/samples/side-navigation-level2.html
@@ -1,9 +1,13 @@
-<details class="side-navigation-toggle" aria-label="Toggle side navigation">
+<details
+  class="side-navigation-toggle"
+  aria-label="Toggle side navigation"
+  aria-expanded="false"
+  aria-controls="side-nav-content">
   <summary>
     <span class="container d-block">Side navigation</span>
   </summary>
 </details>
-<div class="container">
+<div class="container" id="side-nav-content">
   <nav aria-label="list navigation" class="side-navigation">
     <ul>
       <li><a href="javascript:;" class="landing">Landing page</a></li>

--- a/sample_site/pages/samples/side-navigation-level3.html
+++ b/sample_site/pages/samples/side-navigation-level3.html
@@ -1,9 +1,13 @@
-<details class="side-navigation-toggle" aria-label="Toggle side navigation">
+<details
+  class="side-navigation-toggle"
+  aria-label="Toggle side navigation"
+  aria-expanded="false"
+  aria-controls="side-nav-content">
   <summary>
     <span class="container d-block">Side navigation</span>
   </summary>
 </details>
-<div class="container">
+<div class="container" id="side-nav-content">
   <nav aria-label="list navigation" class="side-navigation">
     <ul>
       <li>

--- a/sample_site/pages/samples/side-navigation.html
+++ b/sample_site/pages/samples/side-navigation.html
@@ -1,9 +1,13 @@
-<details class="side-navigation-toggle" aria-label="Toggle side navigation">
+<details
+  class="side-navigation-toggle"
+  aria-label="Toggle side navigation"
+  aria-expanded="false"
+  aria-controls="side-nav-content">
   <summary>
     <span class="container d-block">Side navigation</span>
   </summary>
 </details>
-<div class="container">
+<div class="container" id="side-nav-content">
   <nav aria-label="Side navigation" class="side-navigation">
     <ul>
       <li>

--- a/sample_site/pages/top-task-1-content-1.html
+++ b/sample_site/pages/top-task-1-content-1.html
@@ -20,12 +20,16 @@ title: Top task 1 Content page 1
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-1-content-2.html
+++ b/sample_site/pages/top-task-1-content-2.html
@@ -20,12 +20,16 @@ title: Top task 1 Content page 2
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-1-content-3.html
+++ b/sample_site/pages/top-task-1-content-3.html
@@ -20,12 +20,16 @@ title: Top task 1 Content page 3
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-1-content-4.html
+++ b/sample_site/pages/top-task-1-content-4.html
@@ -20,12 +20,16 @@ title: Top task 1 Content page 4
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-1.html
+++ b/sample_site/pages/top-task-1.html
@@ -25,12 +25,14 @@ title: Top task 1
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/sample_site/pages/top-task-2-content-1.html
+++ b/sample_site/pages/top-task-2-content-1.html
@@ -20,12 +20,16 @@ title: Top task 2 Content page 1
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-2-content-2.html
+++ b/sample_site/pages/top-task-2-content-2.html
@@ -20,12 +20,16 @@ title: Top task 2 Content page 1
 <div class="row">
   <div class="col-lg-3 pe-lg-5" role="complementary">
     <!-- Side navigation -->
-    <details class="side-navigation-toggle" aria-label="Toggle side navigation">
+    <details
+      class="side-navigation-toggle"
+      aria-label="Toggle side navigation"
+      aria-expanded="false"
+      aria-controls="side-nav-content">
       <summary>
         <span class="container d-block">Side navigation</span>
       </summary>
     </details>
-    <div class="container">
+    <div class="container" id="side-nav-content">
       <nav aria-label="list navigation" class="side-navigation">
         <ul>
           <li>

--- a/sample_site/pages/top-task-2.html
+++ b/sample_site/pages/top-task-2.html
@@ -25,12 +25,14 @@ title: Top task2
     <aside class="col-12 col-lg-3 pt-lg-5">
       <details
         class="side-navigation-toggle"
-        aria-label="Toggle side navigation">
+        aria-label="Toggle side navigation"
+        aria-expanded="false"
+        aria-controls="side-nav-content">
         <summary>
           <span class="container d-block">Side navigation</span>
         </summary>
       </details>
-      <div class="container">
+      <div class="container" id="side-nav-content">
         <nav aria-label="Side navigation" class="side-navigation">
           <ul>
             <li>

--- a/src/js/cagov/side-navigation.js
+++ b/src/js/cagov/side-navigation.js
@@ -66,7 +66,27 @@ window.addEventListener("load", () => {
     });
   };
 
+  /**
+   * Toggle aria-expanded attribute on details element
+   */
+  function accessibilityToggle() {
+    const detailsToggle = document.querySelector(".side-navigation-toggle");
+    if (!detailsToggle) return;
+
+    // Check if aria-expanded exists, if not, set it to false
+    if (!detailsToggle.hasAttribute("aria-expanded")) {
+      detailsToggle.setAttribute("aria-expanded", "false");
+    }
+
+    // Listen for toggle event and update aria-expanded
+    detailsToggle.addEventListener("toggle", () => {
+      const isOpen = detailsToggle.hasAttribute("open");
+      detailsToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    });
+  }
+
   // ONLOAD
+  accessibilityToggle();
   sidenavOverflow();
   addActiveClass();
 });


### PR DESCRIPTION
## Accessibility Improvements: Side Navigation Component

### What's Changed
- Added `accessibilityToggle()` function to manage `aria-expanded` attribute on the `.side-navigation-toggle` `<details>` element

### Details

#### Added `accessibilityToggle()` Function
- **On Load:** Checks if `aria-expanded` attribute exists on the details toggle element. If missing, initializes it to `"false"`
- **On Toggle:** Listens for the `toggle` event and dynamically updates `aria-expanded` to reflect the details element's open/closed state
  - `aria-expanded="true"` when the details element is open
  - `aria-expanded="false"` when the details element is closed

#### Related Markup Structure
The function works with the following accessible markup pattern:
```html
<details
  class="side-navigation-toggle"
  aria-label="Toggle side navigation"
  aria-expanded="false"
  aria-controls="side-nav-content">
  <summary>Side navigation</summary>
</details>

<div class="container" id="side-nav-content">
  <nav aria-label="list navigation" class="side-navigation">
    <!-- Navigation content -->
  </nav>
</div>