### PR TITLE
Added necessary aria attributes to header independent components

### DIFF
--- a/sample_site/pages/independent-components/cagov-header-full/cagov-header-full.html
+++ b/sample_site/pages/independent-components/cagov-header-full/cagov-header-full.html
@@ -4,9 +4,11 @@ permalink: cagov-header-full.html
 title: Components and patterns
 ---
 
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
+<!-- This meta tag is for responsive design and ensures the page scales correctly on different devices. 
+ Omit it if your site has a different method for handling responsive design. -->
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- Components start-->
 <div class="cagov-header-full">
   <!-- START > div:first-child (Utility Bar) -->
   <div>
@@ -14,13 +16,15 @@ title: Components and patterns
     <div>
       <!-- START > details:first-of-type (Official CA.gov Button) -->
       <details
-        name="cagov-header-full__buttongroup">
+        name="cagov-header-full__buttongroup"
+        aria-controls="cagov-header-full__official-ca-gov"
+        aria-expanded="false">
         <summary>Official California website</summary>
       </details>
       <!-- END > details:first-of-type (Official CA.gov Button) -->
 
       <!-- START > details:first-of-type + div (Official CA.gov Content) -->
-      <div>
+      <div id="cagov-header-full__official-ca-gov">
         <span class="bold">California government websites use .ca.gov </span
         ><br />
         A .ca.gov website is part of California’s government.
@@ -47,13 +51,15 @@ title: Components and patterns
 
       <!-- START > details:last-of-type (Utility Menu Button) -->
       <details
-        name="cagov-header-full__buttongroup">
+        name="cagov-header-full__buttongroup"
+        aria-controls="cagov-header-full__utility-menu"
+        aria-expanded="false">
         <summary lang="en">Utility menu</summary>
       </details>
       <!-- END > details:last-of-type (Utility Menu Button) -->
 
       <!-- START > div:last-of-type (Utility Menu Content) -->
-      <div>
+      <div id="cagov-header-full__utility-menu">
         <nav aria-label="Utility navigation">
           <ul>
             <li>
@@ -133,7 +139,9 @@ title: Components and patterns
 
       <!-- START > details:first-of-type (Search Button) -->
       <details
-        name="cagov-header-full__buttongroup">
+        name="cagov-header-full__buttongroup"
+        aria-expanded="false"
+        aria-controls="cagov-header-full__search-form">
         <summary>
           <span lang="en">CA.gov search</span>
           <svg
@@ -152,15 +160,13 @@ title: Components and patterns
       <!-- END > details:first-of-type (Search Button) -->
 
       <!-- START > div:nth-of-type(2) (Search Form) -->
-      <div>
+      <div id="cagov-header-full__search-form">
         <form
           action="https://www.ca.gov/search/"
           method="get"
           role="search"
           aria-label="Search CA.gov">
-          <label for="cagov-search-input"
-            >Search CA.gov</label
-          >
+          <label for="cagov-search-input">Search CA.gov</label>
           <input
             type="search"
             id="cagov-search-input"
@@ -187,17 +193,18 @@ title: Components and patterns
 
       <!-- START > details:last-of-type (Main Menu Button) -->
       <details
-        name="cagov-header-full__buttongroup">
+        name="cagov-header-full__buttongroup"
+        aria-controls="cagov-header-full__main-menu-content"
+        aria-expanded="false">
         <summary lang="en">
           <span>Main menu</span>
-          <span
-            aria-hidden="true"></span>
+          <span aria-hidden="true"></span>
         </summary>
       </details>
       <!-- END > details:last-of-type (Main Menu Button) -->
 
       <!-- START > div:last-of-type (Main Menu Content) -->
-      <div>
+      <div id="cagov-header-full__main-menu-content">
         <nav aria-label="Main navigation">
           <ul>
             <li>

--- a/sample_site/pages/independent-components/cagov-header-full/cagov-header-full.html.js
+++ b/sample_site/pages/independent-components/cagov-header-full/cagov-header-full.html.js
@@ -32,4 +32,24 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
   // End details.name polyfill
+
+  /**
+   * Toggle aria-expanded attribute on all details elements in the button group
+   */
+  function accessibilityToggle() {
+    const detailsToggles = document.querySelectorAll(
+      'details[name="cagov-header-full__buttongroup"]'
+    );
+
+    detailsToggles.forEach(detailsToggle => {
+      detailsToggle.setAttribute("aria-expanded", "false");
+
+      detailsToggle.addEventListener("toggle", () => {
+        const isOpen = detailsToggle.hasAttribute("open");
+        detailsToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      });
+    });
+  }
+
+  accessibilityToggle();
 });

--- a/sample_site/pages/independent-components/cagov-header/cagov-header.html
+++ b/sample_site/pages/independent-components/cagov-header/cagov-header.html
@@ -4,9 +4,11 @@ permalink: cagov-header.html
 title: Components and patterns
 ---
 
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
+<!-- This meta tag is for responsive design and ensures the page scales correctly on different devices. 
+ Omit it if your site has a different method for handling responsive design. -->
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- Components start-->
 <div class="cagov-header">
   <div>
     <div>
@@ -104,9 +106,7 @@ title: Components and patterns
           method="get"
           role="search"
           aria-label="Search CA.gov">
-          <label for="cagov-search-input"
-            >Search CA.gov</label
-          >
+          <label for="cagov-search-input">Search CA.gov</label>
           <input
             type="search"
             id="cagov-search-input"

--- a/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html
+++ b/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html
@@ -8,9 +8,10 @@ title: Components and patterns
   {% include "./cagov-utility-header.html.css" %}
 </style>
 
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
+<!-- This meta tag is for responsive design and ensures the page scales correctly on different devices. 
+ Omit it if your site has a different method for handling responsive design. -->
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
 <div class="cagov-utility-header">
   <!-- START > div (Utility Wrapper) -->
   <div>
@@ -41,19 +42,22 @@ title: Components and patterns
                 d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-60 1-103-42-103-102C47 92 92 47 150 47c32 0 61 13 87 39l19-47c-29-24-66-38-104-38C110 1 73 15 45 42C16 69 0 107 0 150c0 87 62 149 150 149z" />
               <path
                 fill="#326130"
-                d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-42 0-74-20-91-51H8c19 60 72 98 142 98z" /></svg></a>
+                d="M150 299c32 0 55-6 76-18l5-11c-7 1-14 2-20 2h-3l-2-1c-5-1-12-5-19-11-3-2-7-6-11-11-8 2-16 3-26 3-42 0-74-20-91-51H8c19 60 72 98 142 98z" /></svg
+          ></a>
         </div>
         <!-- END > div:first-of-type (CA.gov Logo) -->
 
         <!-- START > details:first-of-type (CA.gov Menu Button) -->
         <details
-          name="cagov-utility-header__buttongroup">
+          name="cagov-utility-header__buttongroup"
+          aria-expanded="false"
+          aria-controls="cagov-utility-header__menu-content">
           <summary lang="en">CA.gov menu</summary>
         </details>
         <!-- END > details:first-of-type (CA.gov Menu Button) -->
 
         <!-- START > div:nth-of-type(2) (CA.gov Menu Content) -->
-        <div>
+        <div id="cagov-utility-header__menu-content">
           <nav aria-label="CA.gov navigation">
             <ul>
               <li>
@@ -77,7 +81,9 @@ title: Components and patterns
 
         <!-- START > details:last-of-type (Search Button) -->
         <details
-          name="cagov-utility-header__buttongroup">
+          name="cagov-utility-header__buttongroup"
+          aria-expanded="false"
+          aria-controls="cagov-utility-header__search-content">
           <summary>
             <span class="cagov-sr-only" lang="en">CA.gov search</span>
             <svg
@@ -94,7 +100,7 @@ title: Components and patterns
         <!-- END > details:last-of-type (Search Button) -->
 
         <!-- START > div:last-of-type (Search Content) -->
-        <div>
+        <div id="cagov-utility-header__search-content">
           <form
             action="https://www.ca.gov/search/"
             method="get"

--- a/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html.js
+++ b/sample_site/pages/independent-components/cagov-utility-header/cagov-utility-header.html.js
@@ -32,4 +32,24 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
   // End details.name polyfill
+
+  /**
+   * Toggle aria-expanded attribute on all details elements in the button group
+   */
+  function accessibilityToggle() {
+    const detailsToggles = document.querySelectorAll(
+      'details[name="cagov-utility-header__buttongroup"]'
+    );
+
+    detailsToggles.forEach(detailsToggle => {
+      detailsToggle.setAttribute("aria-expanded", "false");
+
+      detailsToggle.addEventListener("toggle", () => {
+        const isOpen = detailsToggle.hasAttribute("open");
+        detailsToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      });
+    });
+  }
+
+  accessibilityToggle();
 });

--- a/sample_site/pages/independent-components/template-header-full/template-header-full.html
+++ b/sample_site/pages/independent-components/template-header-full/template-header-full.html
@@ -4,9 +4,11 @@ permalink: template-header-full.html
 title: Components and patterns
 ---
 
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no" />
+<!-- This meta tag is for responsive design and ensures the page scales correctly on different devices. 
+ Omit it if your site has a different method for handling responsive design. -->
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- Component start -->
 <div class="template-header-full">
   <!-- START > div:first-child (Utility Bar) -->
   <div>
@@ -104,7 +106,10 @@ title: Components and patterns
       <!-- END > div:first-of-type (Site Logo) -->
 
       <!-- START > details:first-of-type (Search Button) -->
-      <details name="template-header-full__buttongroup">
+      <details
+        name="template-header-full__buttongroup"
+        aria-expanded="false"
+        aria-controls="template-header-full__cagov-search">
         <summary>
           <span class="template-sr-only" lang="en">CA.gov search</span>
           <svg
@@ -123,7 +128,7 @@ title: Components and patterns
       <!-- END > details:first-of-type (Search Button) -->
 
       <!-- START > div:nth-of-type(2) (Search Form) -->
-      <div>
+      <div id="template-header-full__cagov-search">
         <form
           action="https://www.ca.gov/search/"
           method="get"
@@ -157,7 +162,10 @@ title: Components and patterns
       <!-- END > div:nth-of-type(2) (Search Form) -->
 
       <!-- START > details:last-of-type (Main Menu Button) -->
-      <details name="template-header-full__buttongroup">
+      <details
+        name="template-header-full__buttongroup"
+        aria-expanded="false"
+        aria-controls="template-header-full__main-menu">
         <summary lang="en">
           <span class="template-sr-only">Main menu</span>
           <span aria-hidden="true"></span>
@@ -166,7 +174,7 @@ title: Components and patterns
       <!-- END > details:last-of-type (Main Menu Button) -->
 
       <!-- START > div:last-of-type (Main Menu Content) -->
-      <div>
+      <div id="template-header-full__main-menu">
         <nav aria-label="Main navigation">
           <ul>
             <li>

--- a/sample_site/pages/independent-components/template-header-full/template-header-full.html.js
+++ b/sample_site/pages/independent-components/template-header-full/template-header-full.html.js
@@ -32,4 +32,24 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
   // End details.name polyfill
+
+  /**
+   * Toggle aria-expanded attribute on all details elements in the button group
+   */
+  function accessibilityToggle() {
+    const detailsToggles = document.querySelectorAll(
+      'details[name="template-header-full__buttongroup"]'
+    );
+
+    detailsToggles.forEach(detailsToggle => {
+      detailsToggle.setAttribute("aria-expanded", "false");
+
+      detailsToggle.addEventListener("toggle", () => {
+        const isOpen = detailsToggle.hasAttribute("open");
+        detailsToggle.setAttribute("aria-expanded", isOpen ? "true" : "false");
+      });
+    });
+  }
+
+  accessibilityToggle();
 });


### PR DESCRIPTION
# Add ARIA attributes to header independent components

## Summary

Added `aria-expanded` and `aria-controls` attributes to `<details>` disclosure widgets across header components to improve screen reader accessibility. Previously, the `<details>` elements controlled sibling `<div>` menus via CSS only, with no programmatic relationship between the trigger and its content.

## Changes

### `cagov-header-full`
- Added `aria-controls` and `aria-expanded="false"` to all four `<details>` elements (Official CA.gov, Login/Utility menu, Search, Main menu)
- Added matching `id` attributes to all controlled `<div>` content panels
- Added `accessibilityToggle()` function in `.html.js` that uses `querySelectorAll` to attach a `toggle` event listener to all `details[name="cagov-header-full__buttongroup"]` elements, keeping `aria-expanded` in sync with the native `open` attribute

### `cagov-utility-header`
- Same `aria-controls` / `aria-expanded` pattern applied
- Added `accessibilityToggle()` in `.html.js`

### `template-header-full`
- Same `aria-controls` / `aria-expanded` pattern applied
- Added `accessibilityToggle()` in `.html.js`

## Accessibility impact

- Screen readers now correctly announce the expanded/collapsed state of each disclosure widget
- `aria-controls` establishes a programmatic relationship between each `<details>` button and its content panel
- Removing `user-scalable=no` from the viewport meta restores pinch-to-zoom for users who need it (WCAG 1.4.4)
